### PR TITLE
Feature/#19 electricity import limit

### DIFF
--- a/windnode_abw/model/region/model.py
+++ b/windnode_abw/model/region/model.py
@@ -1242,6 +1242,9 @@ def imported_electricity_limit(om):
     el_demand_flows = [(i, o) for (i, o) in om.FLOWS if o.label.startswith(el_demand_labels)]
     battery_storage_charge_flows = [(i, o) for (i, o) in om.FLOWS if o.label.startswith("flex_bat")]
     battery_storage_discharge_flows = [(i, o) for (i, o) in om.FLOWS if i.label.startswith("flex_bat")]
+    grid_flows_to_grid = [(i, o) for (i, o) in om.FLOWS if isinstance(o, solph.custom.Link)]
+    grid_flows_to_bus = [(i, o) for (i, o) in om.FLOWS if isinstance(i, solph.custom.Link)]
+
     def _import_limit_rule(om):
         lhs = sum(om.flow[i, o, t]
                   for (i, o) in import_flows
@@ -1254,6 +1257,12 @@ def imported_electricity_limit(om):
                    for t in om.TIMESTEPS) -
                sum(om.flow[i, o, t]
                    for (i, o) in battery_storage_discharge_flows
+                   for t in om.TIMESTEPS) +
+               sum(om.flow[i, o, t]
+                   for (i, o) in grid_flows_to_grid
+                   for t in om.TIMESTEPS) -
+               sum(om.flow[i, o, t]
+                   for (i, o) in grid_flows_to_bus
                    for t in om.TIMESTEPS))
 
         return lhs <= rhs

--- a/windnode_abw/model/region/model.py
+++ b/windnode_abw/model/region/model.py
@@ -32,7 +32,7 @@ def simulate(esys, scn_data, solver='cbc', verbose=True, save_lp=False):
 
     # Add electricity import limit
     el_import_limit = scn_data['grid']['extgrid'][
-        'imex_lines']['params']['limit']
+        'imex_lines']['params']['energy_limit']
     if el_import_limit < 1:
         imported_electricity_limit(om, limit=el_import_limit)
 
@@ -337,14 +337,14 @@ def create_el_model(region=None, datetime_index=None):
                         nominal_value=s_nom *
                                       scn_data['grid']['extgrid'][
                                           'imex_lines']['params'][
-                                          'max_usable_capacity'],
+                                          'power_limit'],
                         **scn_data['grid']['extgrid']['imex_lines']['outflow']
                     ),
                     imex_bus: solph.Flow(
                         nominal_value=s_nom *
                                       scn_data['grid']['extgrid'][
                                           'imex_lines']['params'][
-                                          'max_usable_capacity'],
+                                          'power_limit'],
                         **scn_data['grid']['extgrid']['imex_lines']['outflow']
                     )
                 },

--- a/windnode_abw/model/region/model.py
+++ b/windnode_abw/model/region/model.py
@@ -11,7 +11,7 @@ from windnode_abw.model.region.tools import calc_heat_pump_cops, \
     calc_dsm_cap_down, calc_dsm_cap_up, create_maintenance_timeseries
 
 
-def simulate(esys, solver='cbc', verbose=True):
+def simulate(esys, solver='cbc', verbose=True, save_lp=False):
     """Optimize energy system
 
     Parameters
@@ -32,6 +32,16 @@ def simulate(esys, solver='cbc', verbose=True):
 
     # Add electricity import limit
     imported_electricity_limit(om)
+
+    # Save .lp file
+    if save_lp:
+        from windnode_abw.tools import config
+        om.write(os.path.join(config.get_data_root_dir(),
+                              config.get('user_dirs',
+                                         'log_dir'),
+                              "windnode_abw.lp"),
+                 io_options={'symbolic_solver_labels': True})
+
     # solve it
     log_memory_usage()
     logger.info('Solve optimization problem...')

--- a/windnode_abw/model/region/model.py
+++ b/windnode_abw/model/region/model.py
@@ -1236,6 +1236,27 @@ def create_flexopts(region=None, datetime_index=None, esys_nodes=[]):
 
 
 def imported_electricity_limit(om):
+    """
+    Limit the annual imported electricity from national system
+
+    Adds a constraint to the optimization problem that limits imported electricity
+    from the national system to a certain share of total consumed electricity.
+
+    .. math::
+
+        \sum_{tr \in Trafos_{HV/EHV} } \sum_t P_{tr} \left( t \right)
+        \leq limit
+        \cdot \sum_t \left( \sum_{d \in demand_{el}} P_d(t)
+        + \sum_{s \in storages_{el}} P_{loss,s}(t)
+        + \sum_{l \in lines} P_{loss,l}(t)
+        + \sum_{hp \in heat\_pump_{el}} P_{el,hp}(t) \right)
+
+    Parameters
+    ----------
+
+    om : :class:`OperationalModel <oemof.solph.Model>`
+        Instance of oemof.solph operational model
+    """
     el_demand_labels = ("dem_el", "flex_dsm", "flex_dec_pth", "trans_dummy_th_dec_pth, flex_cen_pth")
 
     import_flows = [(i, o) for (i, o) in om.FLOWS if i.label.startswith("shortage_el")]

--- a/windnode_abw/model/region/model.py
+++ b/windnode_abw/model/region/model.py
@@ -31,7 +31,8 @@ def simulate(esys, scn_data, solver='cbc', verbose=True, save_lp=False):
     om = solph.Model(esys)
 
     # Add electricity import limit
-    imported_electricity_limit(om, scn_data)
+    if scn_data['grid']['extgrid']['imex_lines']['params']['limit'] < 1:
+        imported_electricity_limit(om, scn_data)
 
     # Save .lp file
     if save_lp:

--- a/windnode_abw/model/region/model.py
+++ b/windnode_abw/model/region/model.py
@@ -1276,20 +1276,21 @@ def imported_electricity_limit(om, limit):
                   for (i, o) in import_flows
                   for t in om.TIMESTEPS)
         rhs = limit * (sum(om.flow[i, o, t]
-                   for (i, o) in el_demand_flows
-                   for t in om.TIMESTEPS) +
-               sum(om.flow[i, o, t]
-                   for (i, o) in battery_storage_charge_flows
-                   for t in om.TIMESTEPS) -
-               sum(om.flow[i, o, t]
-                   for (i, o) in battery_storage_discharge_flows
-                   for t in om.TIMESTEPS) +
-               sum(om.flow[i, o, t]
-                   for (i, o) in grid_flows_to_grid
-                   for t in om.TIMESTEPS) -
-               sum(om.flow[i, o, t]
-                   for (i, o) in grid_flows_to_bus
-                   for t in om.TIMESTEPS))
+                           for (i, o) in el_demand_flows
+                           for t in om.TIMESTEPS) +
+                       sum(om.flow[i, o, t]
+                           for (i, o) in battery_storage_charge_flows
+                           for t in om.TIMESTEPS) -
+                       sum(om.flow[i, o, t]
+                           for (i, o) in battery_storage_discharge_flows
+                           for t in om.TIMESTEPS) +
+                       sum(om.flow[i, o, t]
+                           for (i, o) in grid_flows_to_grid
+                           for t in om.TIMESTEPS) -
+                       sum(om.flow[i, o, t]
+                           for (i, o) in grid_flows_to_bus
+                           for t in om.TIMESTEPS)
+                       )
 
         return lhs <= rhs
 

--- a/windnode_abw/model/region/model.py
+++ b/windnode_abw/model/region/model.py
@@ -1262,14 +1262,26 @@ def imported_electricity_limit(om, limit):
     limit : float
         Electricity imports limit from external grid (0..1)
     """
-    el_demand_labels = ("dem_el", "flex_dsm", "flex_dec_pth", "trans_dummy_th_dec_pth, flex_cen_pth")
+    el_demand_labels = ("dem_el", "flex_dsm", "flex_dec_pth", "flex_cen_pth")
 
-    import_flows = [(i, o) for (i, o) in om.FLOWS if i.label.startswith("shortage_el")]
-    el_demand_flows = [(i, o) for (i, o) in om.FLOWS if o.label.startswith(el_demand_labels)]
-    battery_storage_charge_flows = [(i, o) for (i, o) in om.FLOWS if o.label.startswith("flex_bat")]
-    battery_storage_discharge_flows = [(i, o) for (i, o) in om.FLOWS if i.label.startswith("flex_bat")]
-    grid_flows_to_grid = [(i, o) for (i, o) in om.FLOWS if isinstance(o, solph.custom.Link)]
-    grid_flows_to_bus = [(i, o) for (i, o) in om.FLOWS if isinstance(i, solph.custom.Link)]
+    import_flows = [(i, o)
+                    for (i, o) in om.FLOWS
+                    if i.label.startswith("shortage_el")]
+    el_demand_flows = [(i, o)
+                       for (i, o) in om.FLOWS
+                       if o.label.startswith(el_demand_labels)]
+    battery_storage_charge_flows = [(i, o)
+                                    for (i, o) in om.FLOWS
+                                    if o.label.startswith("flex_bat")]
+    battery_storage_discharge_flows = [(i, o)
+                                       for (i, o) in om.FLOWS
+                                       if i.label.startswith("flex_bat")]
+    grid_flows_to_grid = [(i, o)
+                          for (i, o) in om.FLOWS
+                          if isinstance(o, solph.custom.Link)]
+    grid_flows_to_bus = [(i, o)
+                         for (i, o) in om.FLOWS
+                         if isinstance(i, solph.custom.Link)]
 
     def _import_limit_rule(om):
         lhs = sum(om.flow[i, o, t]

--- a/windnode_abw/run_scenario.py
+++ b/windnode_abw/run_scenario.py
@@ -86,6 +86,7 @@ def run_scenario(cfg):
     #                    draw=True)
 
     om = simulate(esys=esys,
+                  scn_data=region.cfg['scn_data'],
                   solver=cfg['solver'],
                   save_lp=True)
 

--- a/windnode_abw/run_scenario.py
+++ b/windnode_abw/run_scenario.py
@@ -94,7 +94,7 @@ def run_scenario(cfg):
     om = simulate(esys=esys,
                   scn_data=region.cfg['scn_data'],
                   solver=cfg['solver'],
-                  save_lp=True)
+                  save_lp=cfg['save_lp'])
 
     log_memory_usage()
     logger.info('Processing results...')
@@ -142,6 +142,7 @@ if __name__ == "__main__":
                                                 'results_dir')),
         'solver': 'gurobi',
         'verbose': True,
+        'save_lp': True,
         'dump_esys': False,
         'load_esys': False,
         'dump_results': True

--- a/windnode_abw/run_scenario.py
+++ b/windnode_abw/run_scenario.py
@@ -73,8 +73,9 @@ def run_scenario(cfg):
     # x.plot()
 
     log_memory_usage()
-    esys = create_oemof_model(cfg=cfg,
-                              region=region)
+    esys, om = create_oemof_model(region=region,
+                                  cfg=cfg,
+                                  save_lp=cfg['save_lp'])
 
     # # create and plot graph of energy system
     # graph = create_nx_graph(esys)
@@ -91,11 +92,9 @@ def run_scenario(cfg):
     # graph = grid_graph(region=region,
     #                    draw=True)
 
-    om = simulate(esys=esys,
-                  scn_data=region.cfg['scn_data'],
+    om = simulate(om=om,
                   solver=cfg['solver'],
-                  verbose=cfg['verbose'],
-                  save_lp=cfg['save_lp'])
+                  verbose=cfg['verbose'])
 
     log_memory_usage()
     logger.info('Processing results...')

--- a/windnode_abw/run_scenario.py
+++ b/windnode_abw/run_scenario.py
@@ -94,6 +94,7 @@ def run_scenario(cfg):
     om = simulate(esys=esys,
                   scn_data=region.cfg['scn_data'],
                   solver=cfg['solver'],
+                  verbose=cfg['verbose'],
                   save_lp=cfg['save_lp'])
 
     log_memory_usage()

--- a/windnode_abw/run_scenario.py
+++ b/windnode_abw/run_scenario.py
@@ -86,7 +86,8 @@ def run_scenario(cfg):
     #                    draw=True)
 
     om = simulate(esys=esys,
-                  solver=cfg['solver'])
+                  solver=cfg['solver'],
+                  save_lp=True)
 
     log_memory_usage()
     logger.info('Processing results...')

--- a/windnode_abw/scenarios/NEP2035.scn
+++ b/windnode_abw/scenarios/NEP2035.scn
@@ -241,6 +241,9 @@
                 # max_usable_capacity: usable cap. of external grid
                 # (rel. to nominal power)
                 max_usable_capacity = 0.1
+                # limit: 0..1 limiting electricity imports from external grid
+                # set to 1 to deactivate
+                limit = .25
             [[[[outflow]]]]
                 variable_costs = 0.0001
 

--- a/windnode_abw/scenarios/NEP2035.scn
+++ b/windnode_abw/scenarios/NEP2035.scn
@@ -244,12 +244,14 @@
             [[[[params]]]]
                 # conversion_factor: efficiency
                 conversion_factor = 0.988
-                # max_usable_capacity: usable cap. of external grid
+                # power_limit: 0..1
+                # usable cap. of external grid
                 # (rel. to nominal power)
-                max_usable_capacity = 0.1
-                # limit: 0..1 limiting electricity imports from external grid
-                # set to 1 to deactivate
-                limit = .25
+                power_limit = 1
+                # energy_limit: 0..1, set to 1 to deactivate
+                # limiting electricity imports from external grid
+                # (annual amount rel. to el. demand)
+                energy_limit = .25
             [[[[outflow]]]]
                 variable_costs = 0.0001
 

--- a/windnode_abw/scenarios/sq.scn
+++ b/windnode_abw/scenarios/sq.scn
@@ -242,7 +242,8 @@
                 # (rel. to nominal power)
                 max_usable_capacity = 0.1
                 # limit: 0..1 limiting electricity imports from external grid
-                limit = 0.5
+                # set to 1 to deactivate
+                limit = 0.25
             [[[[outflow]]]]
                 variable_costs = 0.0001
 

--- a/windnode_abw/scenarios/sq.scn
+++ b/windnode_abw/scenarios/sq.scn
@@ -241,6 +241,8 @@
                 # max_usable_capacity: usable cap. of external grid
                 # (rel. to nominal power)
                 max_usable_capacity = 0.1
+                # limit: 0..1 limiting electricity imports from external grid
+                limit = 0.5
             [[[[outflow]]]]
                 variable_costs = 0.0001
 

--- a/windnode_abw/scenarios/sq.scn
+++ b/windnode_abw/scenarios/sq.scn
@@ -244,12 +244,14 @@
             [[[[params]]]]
                 # conversion_factor: efficiency
                 conversion_factor = 0.988
-                # max_usable_capacity: usable cap. of external grid
+                # power_limit: 0..1
+                # usable cap. of external grid
                 # (rel. to nominal power)
-                max_usable_capacity = 0.1
-                # limit: 0..1 limiting electricity imports from external grid
-                # set to 1 to deactivate
-                limit = 1
+                power_limit = 1
+                # energy_limit: 0..1, set to 1 to deactivate
+                # limiting electricity imports from external grid
+                # (annual amount rel. to el. demand)
+                energy_limit = 1
             [[[[outflow]]]]
                 variable_costs = 0.0001
 

--- a/windnode_abw/scenarios/sq.scn
+++ b/windnode_abw/scenarios/sq.scn
@@ -243,7 +243,7 @@
                 max_usable_capacity = 0.1
                 # limit: 0..1 limiting electricity imports from external grid
                 # set to 1 to deactivate
-                limit = 0.25
+                limit = 1
             [[[[outflow]]]]
                 variable_costs = 0.0001
 


### PR DESCRIPTION
Fix #19 


### Things, not so perfect

- `imported_electricity_limit()` is called in `smulate()`. Is necessary because the `solph.Model()` instance is required to select respective flows
- Selection of flows is label-based -> easy to break