### PR TITLE
Fix/#73 relative line loadings

### DIFF
--- a/windnode_abw/analysis/__init__.py
+++ b/windnode_abw/analysis/__init__.py
@@ -13,7 +13,7 @@ from windnode_abw.tools.data_io import load_results
 from windnode_abw.model import Region
 
 from windnode_abw.analysis.tools import aggregate_flows, aggregate_parameters, flows_timexagsxtech, \
-    results_agsxlevelxtech, create_highlevel_results, results_tech
+    results_agsxlevelxtech, create_highlevel_results, results_tech, additional_results_txaxt
 
 
 def analysis(run_timestamp, scenarios='ALL'):
@@ -94,6 +94,10 @@ def analysis(run_timestamp, scenarios='ALL'):
             # Retrieve parameters from database and config file
             parameters = aggregate_parameters(regions_scns[scn_id], results_raw, flows_txaxt)
             results_scns[scn_id]['parameters'] = parameters
+
+            # Add more parameters derived from flows + parameters
+            results_scns[scn_id]['flows_txaxt'] = additional_results_txaxt(results_scns[scn_id]['flows_txaxt'],
+                                                                           results_scns[scn_id]['parameters'])
 
             # Aggregate flow results along different dimensions (outdated, see #29)
             # only used to access DSM demand increase/decrease

--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -747,8 +747,10 @@ def flows_timexagsxtech(results_raw, region):
 def additional_results_txaxt(flow_results, params):
 
     # Line loadings
-    flow_results["Line loading"] = flow_results["Stromnetz"].div(params["Installed capacity grid"], axis="index")
-    flow_results["Line loading per bus"] = flow_results["Stromnetz per bus"].div(params["Installed capacity grid per bus"], axis="index")
+    flow_results["Line loading"] = flow_results["Stromnetz"].abs().max(axis=1).div(
+        params["Installed capacity grid"], axis="index")
+    flow_results["Line loading per bus"] = flow_results["Stromnetz per bus"].abs().max(axis=1).div(
+        params["Installed capacity grid per bus"], axis="index")
 
     return flow_results
 

--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -693,6 +693,8 @@ def flows_timexagsxtech(results_raw, region):
         [line_flows_exchange_1.rename("out"),
          line_flows_exchange_2.rename("in")], axis=1)
 
+
+
     # Intra-regional exchange as export (region feeds grid) and import (region gets supplied from grid)
     region_export_in_tmp = flows["Stromnetz"][flows["Stromnetz"]["in"] >= 0].groupby(["timestamp", "ags_from"])["in"].sum()
     region_export_in_tmp.index.set_names("ags", level="ags_from", inplace=True)
@@ -740,6 +742,15 @@ def flows_timexagsxtech(results_raw, region):
     flows["Autarky"]["relative"] = flows["Autarky"]['supply'].unstack().div(flows["Autarky"]['demand'].unstack()).stack()
 
     return flows
+
+
+def additional_results_txaxt(flow_results, params):
+
+    # Line loadings
+    flow_results["Line loading"] = flow_results["Stromnetz"].div(params["Installed capacity grid"], axis="index")
+    flow_results["Line loading per bus"] = flow_results["Stromnetz per bus"].div(params["Installed capacity grid per bus"], axis="index")
+
+    return flow_results
 
 
 def non_region_bus2ags(bus_id, region):
@@ -1165,6 +1176,7 @@ def results_agsxlevelxtech(extracted_results, parameters, region):
     results["Autarky"]['relative'] = results["Autarky"]['supply'].div(results["Autarky"]['demand'])
     results["Autarky"]['hours'] = (extracted_results["Autarky"]['relative']>1).sum(level=1).astype(int)
     results["Autarky"].index = results["Autarky"].index.astype(int)
+
     return results
 
 

--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -942,6 +942,7 @@ def aggregate_parameters(region, results_raw, flows):
 
     # Rename to ags
     line_capacity = flows_params["Grid"]["investment_existing"]
+    params["Installed capacity grid per bus"] = line_capacity.copy()
     bus2ags = {str(k): str(int(v)) for k, v in region.buses["ags"].to_dict().items() if not pd.isna(v)}
     line_capacity.rename(index=bus2ags, inplace=True)
     line_capacity = _rename_external_hv_buses(line_capacity, merged=True)[0]
@@ -951,8 +952,9 @@ def aggregate_parameters(region, results_raw, flows):
 
     # ...and aggregate to ags level
     line_capacity = line_capacity.sum(level=["bus_from", "bus_to"])
+    line_capacity.index.names = ["ags_from", "ags_to"]
     params["Installed capacity grid"] = line_capacity.loc[~
-        (line_capacity.index.get_level_values("bus_from") == line_capacity.index.get_level_values("bus_to"))]
+        (line_capacity.index.get_level_values("ags_from") == line_capacity.index.get_level_values("ags_to"))]
 
     return params
 

--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -677,7 +677,7 @@ def flows_timexagsxtech(results_raw, region):
 
     # Grid lines
     line_flows_1 = extract_line_flow(results_raw, region)
-    line_flows_2 = extract_line_flow(results_raw, region)
+    line_flows_2 = extract_line_flow(results_raw, region, level_flow_in=1, level_flow_out=0)
     flows["Stromnetz per bus"] = pd.concat(
         [line_flows_1.rename("out"),
          line_flows_2.rename("in")], axis=1)

--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -747,7 +747,7 @@ def flows_timexagsxtech(results_raw, region):
 def additional_results_txaxt(flow_results, params):
 
     # Line loadings
-    flow_results["Line loading"] = flow_results["Stromnetz"].abs().max(axis=1).div(
+    flow_results["Line loading"] = pd.concat([flow_results["Stromnetz"], flow_results["Stromnetz exchange"]]).abs().max(axis=1).div(
         params["Installed capacity grid"], axis="index")
     flow_results["Line loading per bus"] = flow_results["Stromnetz per bus"].abs().max(axis=1).div(
         params["Installed capacity grid per bus"], axis="index")


### PR DESCRIPTION
Fix #73 

# What has changed

- Flows on lines are now available in two definition
  (a) bus-bus (per bus): Flows on actual lines where one ags can have multiple buses. Data: `results_scns['future']['flows_txaxt']['Stromnetz per bus']` 
  (b) ags-ags: lines are aggregated to one line connecting each pair of ags. Data: `results_scns['future']['flows_txaxt']['Stromnetz']` for lines inside ABW and `results_scns['future']['flows_txaxt']['Stromnetz exchange']` for lines to external grid
- Line loadings are calculated along above definitions. Data: `results_scns['future']['flows_txaxt']['Line loading']`
- Installed capacity is also available in the same definitions. Data: `params["Installed capacity grid"]`
