### PR TITLE
Fix/#34 unlink el heat generators cost emissions

### DIFF
--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -1154,7 +1154,7 @@ def results_agsxlevelxtech(extracted_results, parameters, region):
     # already included in the electricity generation costs
     params_heat_supply_tmp = parameters["Parameters th. generators"].loc[
         parameters["Parameters th. generators"].index != "district_heating"].copy()
-    params_heat_supply_tmp.loc[["elenergy", "pth", "pth_ASHP", "pth_GSHP"], "opex_var_comm"] = 0
+    params_heat_supply_tmp.loc[["elenergy", "pth", "pth_ASHP", "pth_GSHP"], ["opex_var_comm", "emissions_var_comm"]] = 0
     for pth_tech in ["pth_ASHP", "pth_GSHP"]:
         params_heat_supply_tmp.loc[pth_tech + "_stor"] = params_heat_supply_tmp.loc[pth_tech]
         params_heat_supply_tmp.loc[pth_tech + "_nostor"] = params_heat_supply_tmp.loc[pth_tech]

--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -94,14 +94,11 @@ GEN_TH_NAMES = {
         "params": "heating_coal",
         "params_comm": "comm_coal"},
     "pth": {
-        "params": "heating_rod",
-        "params_comm": "elenergy"},
+        "params": "heating_rod"},
     "pth_ASHP": {
-        "params": "heating_ashp",
-        "params_comm": "elenergy"},
+        "params": "heating_ashp"},
     "pth_GSHP": {
-        "params": "heating_gshp",
-        "params_comm": "elenergy"},
+        "params": "heating_gshp"},
     "district_heating": {
         "params": "district_heating"
     }

--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -94,11 +94,14 @@ GEN_TH_NAMES = {
         "params": "heating_coal",
         "params_comm": "comm_coal"},
     "pth": {
-        "params": "heating_rod"},
+        "params": "heating_rod",
+        "params_comm": "elenergy"},
     "pth_ASHP": {
-        "params": "heating_ashp"},
+        "params": "heating_ashp",
+        "params_comm": "elenergy"},
     "pth_GSHP": {
-        "params": "heating_gshp"},
+        "params": "heating_gshp",
+        "params_comm": "elenergy"},
     "district_heating": {
         "params": "district_heating"
     }


### PR DESCRIPTION
Fix #34 

Emissions related to heat generation from PTH and electrical heaters were accounted twice. Now, these emissions are unlinked from heat generation by these technologies and are only considered in the electricity sector. Same is true for costs.