### PR TITLE
Fix/#33 consider gud time dependent efficiency

### DIFF
--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -1170,21 +1170,25 @@ def results_agsxlevelxtech(extracted_results, parameters, region):
     # fix el. emissions for GuD Dessau and BHKWs manually,
     # cf. https://github.com/windnode/WindNODE_ABW/issues/33
     results_tmp_el["CO2 emissions el. var"].at[15001000, 'gud'] = (
-        extracted_results["GuD Dessau"]['out_el'] /
-        (extracted_results["GuD Dessau"]['out_el'] + extracted_results["GuD Dessau"]['out_th']) *
-        extracted_results["GuD Dessau"]['in_gas'] *
-        parameters["Parameters el. generators"].at["gud", "emissions_var_comm"]
-    ).sum() / 1e3
+        (extracted_results["GuD Dessau"]['out_el'].sum() *
+         parameters["Parameters el. generators"].at["gud", "emissions_var"]) +
+        (extracted_results["GuD Dessau"]['out_el'] /
+         (extracted_results["GuD Dessau"]['out_el'] + extracted_results["GuD Dessau"]['out_th']) *
+         extracted_results["GuD Dessau"]['in_gas'] *
+         parameters["Parameters el. generators"].at["gud", "emissions_var_comm"]
+        ).sum()) / 1e3
     bhkw_gas_in = results["Stromerzeugung nach Gemeinde"]["bhkw"] / \
                   parameters["Parameters el. generators"].at["bhkw", "sys_eff"]
     results_tmp_el["CO2 emissions el. var"]["bhkw"] = (
-        bhkw_gas_in *
-        parameters["Parameters el. generators"].at["bhkw", "sys_eff"] / (
-            parameters["Parameters el. generators"].at["bhkw", "sys_eff"] +
-            parameters["Parameters th. generators"].at["bhkw", "sys_eff"]
-            ) *
-        parameters["Parameters el. generators"].at["bhkw", "emissions_var_comm"]
-    ) / 1e3
+        (results["Stromerzeugung nach Gemeinde"]["bhkw"] *
+         parameters["Parameters el. generators"].at["bhkw", "emissions_var"]) +
+        (bhkw_gas_in *
+         parameters["Parameters el. generators"].at["bhkw", "sys_eff"] / (
+         parameters["Parameters el. generators"].at["bhkw", "sys_eff"] +
+         parameters["Parameters th. generators"].at["bhkw", "sys_eff"]
+         ) *
+         parameters["Parameters el. generators"].at["bhkw", "emissions_var_comm"]
+    )) / 1e3
     results_tmp_el["CO2 emissions el. total"] = \
         results_tmp_el["CO2 emissions el. fix"] + \
         results_tmp_el["CO2 emissions el. var"]


### PR DESCRIPTION
Fixes #33.

* consider variable efficiency of GuD Dessau
* Fix emission calc. for BHKWs

As it was too risky and time-consuming to do major changes in the CO2 calc, I went for this dirty, hacky solution overwriting parts of the results.

I noted, that the tech-specific (not commodity) var emissions are accounted for twice, for el+th.! This can become a problem for CHP but currently, it's 0 so I won't file an issue..