### PR TITLE
Feature/#106 nominal power of heat storages

### DIFF
--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -987,11 +987,11 @@ def aggregate_parameters(region, results_raw, flows):
     params["Installierte Kapazität Großbatterien"] = region.batteries_large
     params["Installierte Kapazität PV-Batteriespeicher"] = region.batteries_small
 
-    # Installed capacity heat storage
-    params["Installed capacity heat storage"] = flows_params["Wärmespeicher"][
+    # Installed discharge(!) power heat storage
+    params["Discharge power heat storage"] = flows_params["Wärmespeicher"][
         "nominal_value"].unstack("level").fillna(0).rename(columns={
         "cen": "stor_th_large", "dec": "stor_th_small"})
-    params["Installed capacity heat storage"].index = params["Installed capacity heat storage"].index.astype(int)
+    params["Discharge power heat storage"].index = params["Discharge power heat storage"].index.astype(int)
 
     # extract static vars from nodes
     stat_params = stat_params_agsxtech(results_raw['params_stat'])

--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -993,6 +993,14 @@ def aggregate_parameters(region, results_raw, flows):
         "cen": "stor_th_large", "dec": "stor_th_small"})
     params["Installed capacity heat storage"].index = params["Installed capacity heat storage"].index.astype(int)
 
+    # extract static vars from nodes
+    stat_params = stat_params_agsxtech(results_raw['params_stat'])
+
+    # Installed capacity heat storage
+    params["Installed capacity heat storage"] = stat_params["Wärmespeicher"].astype(float).groupby(
+        ['ags', 'level']).sum().unstack("level").droplevel(0, axis=1).rename(
+        columns={"cen": "stor_th_large", "dec": "stor_th_small"}).fillna(0)
+
     # Installed capacity electricity supply
     params["Installed capacity electricity supply"] = \
         region.muns.loc[:, region.muns.columns.str.startswith("gen_capacity")]

--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -497,6 +497,21 @@ def extract_flow_params(flow_params_raw, node_pattern, bus_pattern, stubname,
     return params_extract
 
 
+def extract_stat_params(stat_params_raw, node_pattern, stubname, params=None):
+
+    pattern = "_".join([stubname, node_pattern])
+
+    params_extract = stat_params_raw.loc[
+        stat_params_raw.index.get_level_values(0).str.match(pattern)]
+
+    # transform to wide-to-long format and create multiindex from pattern groups
+    params_extract = params_extract.unstack().droplevel(0, axis=1)
+    params_extract.index = pd.MultiIndex.from_frame(
+        params_extract.index.get_level_values(0).str.extract(pattern))
+
+    return params_extract[params]
+
+
 def extract_invest(vars, node_pattern, bus_pattern):
 
     # Get an extract of relevant data
@@ -546,6 +561,24 @@ def flow_params_agsxtech(results_raw):
     params = {}
     for name, patterns in param_extractor.items():
         params[name] = extract_flow_params(results_raw, **patterns)
+
+    return params
+
+
+def stat_params_agsxtech(results_raw):
+
+    # define extraction pattern
+    param_extractor = {
+        "Wärmespeicher": {
+            "node_pattern": "(?P<level>\w{3})(?:_pth)?_(?P<ags>\d+)(?:_)?(?P<sector>hh_efh|hh_mfh|rca)?",
+            "stubname": "stor_th",
+            "params": ["nominal_storage_capacity"]}
+    }
+
+    params = {}
+    results_raw = pd.DataFrame(results_raw)
+    for name, patterns in param_extractor.items():
+        params[name] = extract_stat_params(results_raw, **patterns)
 
     return params
 


### PR DESCRIPTION
Fix #106

The capacity contained in the params were the nominal discharge power, not the storage capacity, wtf!
I had to introduce a stat param extractor similar to the flow extractor, finally the stats params csv is used now ;) @gplssm 

Now, both is contained correctly in `results_scns[scenario]['parameters']['Installed capacity heat storage']` and `results_scns[scenario]['parameters']['Discharge power heat storage']`