### PR TITLE
Feature/#119 pickle results

### DIFF
--- a/docs/energy_system_model.rst
+++ b/docs/energy_system_model.rst
@@ -21,6 +21,44 @@ Model details
 Usage notes
 -----------
 
+Run Optimization
+^^^^^^^^^^^^^^^^
+
+To start the optimization, you can use the command line interface: run script
+`run_scenario.py` from the shell:
+
+.. code-block:: bash
+
+   python run_scenario.py [-h] [--mp [NUMBER]] [SCENARIO [SCENARIO ...]]
+
+where `NUMBER` is the number of threads and `SCENARIOS` the scenarios to be executed. For example,
+to run all scenarios in 4 processes, use
+
+.. code-block:: bash
+
+   python run_scenario.py --mp 4 all
+
+To get help on parameters and available scenarios you can use
+
+.. code-block:: bash
+
+   python run_scenario.py -h
+
+Depending on the system settings, the optimization takes about 1-2 hours for each scenario.
+
+By default, raw results are written to `~/.windnode_abw/results/`, a subdirectory with a timestamp
+(run id) is created (e.g. `~/.windnode_abw/results/2020-08-05_024335/`).
+
+Post-processing results
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The results, aggregated on different temporal and spatial levels, are calculated by post-processing
+the raw results from above. These post-processed data is stored as pickle file in subdirectory
+`./processed` of the run id folder and can be quickly loaded, e.g. from the jupyter notebooks.
+
+By default, this step is automatically performed after the optimization run but can be manually
+triggered by passing `force_new_results=True` to the notebook creation functions (see below).
+
 Analyzing results
 ^^^^^^^^^^^^^^^^^
 

--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -1683,7 +1683,8 @@ def create_highlevel_results(results_tables, results_t, results_txaxt, region):
 def create_scenario_notebook(scenario, run_id,
                              template="scenario_analysis_template.ipynb",
                              output_path=os.path.join(wn_path[0], 'jupy'),
-                             kernel_name=None):
+                             kernel_name=None,
+                             force_new_results=False):
 
     # define data and paths
     input_template = os.path.join(wn_path[0], 'jupy', 'templates', template)
@@ -1695,7 +1696,9 @@ def create_scenario_notebook(scenario, run_id,
         pm.execute_notebook(input_template, output_notebook,
                             parameters={
                                 "scenario": scenario,
-                                "run_timestamp": run_id},
+                                "run_timestamp": run_id,
+                                "force_new_results": force_new_results
+                            },
                             request_save_on_cell_execute=True,
                             kernel_name=kernel_name)
     except FileNotFoundError:
@@ -1714,7 +1717,8 @@ def create_multiple_scenario_notebooks(scenarios, run_id,
                                        template="scenario_analysis_template.ipynb",
                                        output_path=os.path.join(wn_path[0], 'jupy'),
                                        num_processes=None,
-                                       kernel_name=None):
+                                       kernel_name=None,
+                                       force_new_results=False):
 
     if isinstance(scenarios, str):
         scenarios = [scenarios]
@@ -1751,7 +1755,9 @@ def create_multiple_scenario_notebooks(scenarios, run_id,
         errors = pool.apply_async(create_scenario_notebook,
                                   args=(scen, run_id, template,),
                                   kwds={"output_path": output_path,
-                                        "kernel_name": kernel_name}).get()
+                                        "kernel_name": kernel_name,
+                                        "force_new_results": force_new_results}
+                                  ).get()
     pool.close()
     pool.join()
 

--- a/windnode_abw/jupy/templates/scenario_analysis_template.ipynb
+++ b/windnode_abw/jupy/templates/scenario_analysis_template.ipynb
@@ -77,7 +77,8 @@
    "source": [
     "# specify what to import (in path ~/.windnode_abw/)\n",
     "run_timestamp = '2020-07-24_104145_1month'\n",
-    "scenario = 'ISE2050_AUT90_BAThigh'"
+    "scenario = 'ISE2050_AUT90_BAThigh'\n",
+    "force_new_results = False"
    ]
   },
   {
@@ -88,7 +89,8 @@
    "source": [
     "# obtain processed results\n",
     "regions_scns, results_scns = analysis(run_timestamp=run_timestamp,\n",
-    "                                      scenarios=[scenario])"
+    "                                      scenarios=[scenario],\n",
+    "                                      force_new_results=force_new_results)"
    ]
   },
   {

--- a/windnode_abw/run_analysis.py
+++ b/windnode_abw/run_analysis.py
@@ -23,8 +23,7 @@ if __name__ == "__main__":
     scenarios = ['NEP2035']
 
     regions_scns, results_scns = analysis(run_timestamp=run_timestamp,
-                       scenarios=scenarios)
+                                          scenarios=scenarios)
 
     logger.info('===== All done! =====')
 
-    # DO STUFF WITH RESULTS (dict results_scns) HERE

--- a/windnode_abw/run_scenario.py
+++ b/windnode_abw/run_scenario.py
@@ -12,6 +12,7 @@ from windnode_abw.model import Region
 from windnode_abw.model.region.model import simulate, create_oemof_model
 from windnode_abw.model.region.tools import calc_line_loading
 from windnode_abw.model.region.tools import grid_graph
+from windnode_abw.analysis import analysis
 from windnode_abw.analysis.tools import results_to_dataframes
 
 # load configs
@@ -144,6 +145,10 @@ def run_scenario(cfg):
                        solver_meta=esys.results['meta'],
                        infeasible=infeasible)
 
+    if cfg['do_analysis']:
+        analysis(run_timestamp=cfg['run_timestamp'],
+                 scenarios=cfg['scn_data']['general']['id'])
+
     logger.info(f'===== Scenario {cfg["scenario"]} done! =====')
 
     # debug_plot_results(esys=esys,
@@ -220,7 +225,8 @@ if __name__ == "__main__":
         'save_lp': False,
         'dump_esys': False,
         'load_esys': False,
-        'dump_results': True
+        'dump_results': True,
+        'do_analysis': True
     }
 
     infeasible_scenarios = []


### PR DESCRIPTION
Fix #119.

This feature allows to dump & restore processed (analyzed) results using pickle.

Some notes:
- Results of analyses are dumped by default (to subfolder `/run_id/scenario/processed`)
- Results of analyses are loaded by default (if found), recreation can be forced by new param (`False` by default):
  - `analysis([...], force_new_results=True)` (by default it is set to `False` in jupy nb template)
  - `create_multiple_scenario_notebooks([...], force_new_results=True)`
  - `create_scenario_notebook([...], force_new_results=True)`
- Analyses are now automatically created and dumped when the optimization finishes, so future runs will contain these analysis data. I just started a new 1month run for all scenarios on srvsim01 to test the latter and provide a full dataset.

There's one drawback:
- It uses quite some disk space (1 month): ~93 MB for the pickle (compared to ~19 MB for the CSV files).
So we'll have ~1.3 GB per scenario for a full-year run (-> total of ~50 GB for all scenarios). That's ok at my end but depending on the connection it might take longer to download a full package than to create it locally.. (40 x 10min = 6.7h)
- Another option is to exclude the region obj. which would end up in 23 MB for the pickle thus saving 70 MB. Subsequently, in the analysis the region had to be re-imported from DB but the time-consuming processed results could be loaded from pickle. I'd go for this option. What do you think? @gplssm 