### PR TITLE
Remove .get() applied to apply_async()

### DIFF
--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -1794,7 +1794,7 @@ def create_multiple_scenario_notebooks(scenarios, run_id,
                                   kwds={"output_path": output_path,
                                         "kernel_name": kernel_name,
                                         "force_new_results": force_new_results}
-                                  ).get()
+                                  )
     pool.close()
     pool.join()
 

--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -1789,16 +1789,13 @@ def create_multiple_scenario_notebooks(scenarios, run_id,
 
     errors = None
     for scen in scenarios:
-        errors = pool.apply_async(create_scenario_notebook,
-                                  args=(scen, run_id, template,),
-                                  kwds={"output_path": output_path,
-                                        "kernel_name": kernel_name,
-                                        "force_new_results": force_new_results}
-                                  )
+        pool.apply_async(create_scenario_notebook,
+                         args=(scen, run_id, template,),
+                         kwds={"output_path": output_path,
+                               "kernel_name": kernel_name,
+                               "force_new_results": force_new_results}
+                         )
     pool.close()
     pool.join()
 
-    if errors is not None:
-        logger.warning(f'Errors occured during creation of notebooks.')
-    else:
-        logger.info(f'Notebooks for {len(scenarios)} scenarios created without errors.')
+    logger.info(f'Notebooks for {len(scenarios)} scenarios created.')


### PR DESCRIPTION
In the initial version, this get() wasn't there.
It was introduced in

https://github.com/windnode/WindNODE_ABW/commit/6d035580bfd05c0cb9b598b66765aacb35f19556

for I reason I don't know. Maybe related to error message capturing.


Fix #154 