### PR TITLE
Feature/#160 export figures in comparative NB

### DIFF
--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -1812,9 +1812,12 @@ def create_comparative_notebook(scenarios, run_id,
                                 kernel_name=None,
                                 force_new_results=False,
                                 export_figures=False,
-                                figures_output_path=os.path.join(wn_path[0], 'jupy'),
-                                figures_file_type='svg'):
+                                figures_output_path=None,
+                                figures_file_ext='svg'):
     """Create comparative jupyter notebook with all scenarios"""
+
+    if figures_output_path is None:
+        figures_output_path = output_path
 
     if isinstance(scenarios, str):
         scenarios = [scenarios]
@@ -1859,7 +1862,7 @@ def create_comparative_notebook(scenarios, run_id,
                                 "force_new_results": force_new_results,
                                 "export_figures": export_figures,
                                 "figures_output_path": figures_output_path,
-                                "figures_file_type": figures_file_type
+                                "figures_file_ext": figures_file_ext
                             },
                             request_save_on_cell_execute=True,
                             kernel_name=kernel_name)

--- a/windnode_abw/analysis/tools.py
+++ b/windnode_abw/analysis/tools.py
@@ -1810,7 +1810,10 @@ def create_comparative_notebook(scenarios, run_id,
                                 template="scenario_analysis_comparative_template.ipynb",
                                 output_path=os.path.join(wn_path[0], 'jupy'),
                                 kernel_name=None,
-                                force_new_results=False):
+                                force_new_results=False,
+                                export_figures=False,
+                                figures_output_path=os.path.join(wn_path[0], 'jupy'),
+                                figures_file_type='svg'):
     """Create comparative jupyter notebook with all scenarios"""
 
     if isinstance(scenarios, str):
@@ -1853,7 +1856,10 @@ def create_comparative_notebook(scenarios, run_id,
                             parameters={
                                 "scenarios": scenarios,
                                 "run_timestamp": run_id,
-                                "force_new_results": force_new_results
+                                "force_new_results": force_new_results,
+                                "export_figures": export_figures,
+                                "figures_output_path": figures_output_path,
+                                "figures_file_type": figures_file_type
                             },
                             request_save_on_cell_execute=True,
                             kernel_name=kernel_name)

--- a/windnode_abw/jupy/templates/scenario_analysis_comparative_template.ipynb
+++ b/windnode_abw/jupy/templates/scenario_analysis_comparative_template.ipynb
@@ -236,7 +236,10 @@
     "                x=1),\n",
     "    autosize=True)\n",
     "\n",
-    "fig.show()"
+    "fig.show()\n",
+    "\n",
+    "if export_figures:\n",
+    "    fig.write_image(figures_output_path + 'xxx.' + figures_file_type)"
    ]
   },
   {
@@ -799,7 +802,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/windnode_abw/jupy/templates/scenario_analysis_comparative_template.ipynb
+++ b/windnode_abw/jupy/templates/scenario_analysis_comparative_template.ipynb
@@ -76,6 +76,7 @@
     "\n",
     "######### DATA ##########\n",
     "\n",
+    "import os\n",
     "import re\n",
     "import pandas as pd\n",
     "\n",
@@ -142,7 +143,9 @@
     "# Colormap\n",
     "CMAP = px.colors.sequential.GnBu_r\n",
     "#CMAP_NAME_KEY_PLOT = 'GnBu_r'\n",
-    "CMAP_NAME_KEY_PLOT = 'viridis'"
+    "CMAP_NAME_KEY_PLOT = 'viridis'\n",
+    "\n",
+    "figure_export_list = {}"
    ]
   },
   {
@@ -238,8 +241,7 @@
     "\n",
     "fig.show()\n",
     "\n",
-    "if export_figures:\n",
-    "    fig.write_image(figures_output_path + 'xxx.' + figures_file_type)"
+    "figure_export_list[fig.layout.title.text] = fig"
    ]
   },
   {
@@ -280,7 +282,9 @@
     "                xanchor=\"right\",\n",
     "                x=1),\n",
     "    autosize=True)\n",
-    "fig.show()"
+    "fig.show()\n",
+    "\n",
+    "figure_export_list[fig.layout.title.text] = fig"
    ]
   },
   {
@@ -322,7 +326,9 @@
     "    autosize=True)\n",
     "\n",
     "fig.update_xaxes(title_text=\"GWH\", row=2, col=1)\n",
-    "fig.show()"
+    "fig.show()\n",
+    "\n",
+    "figure_export_list[fig.layout.title.text] = fig"
    ]
   },
   {
@@ -360,7 +366,9 @@
     "    autosize=True)\n",
     "\n",
     "fig.update_xaxes(title_text=\"GWH\", row=len(scenarios), col=1, matches='x')\n",
-    "fig.show() "
+    "fig.show()\n",
+    "\n",
+    "figure_export_list[fig.layout.title.text] = fig"
    ]
   },
   {
@@ -398,7 +406,9 @@
     "\n",
     "fig.update_yaxes(title_text=\"GWH\", col=1, row=1, matches='x')\n",
     "fig.update_xaxes(type='category', tickangle=45)\n",
-    "fig.show() "
+    "fig.show()\n",
+    "\n",
+    "figure_export_list[fig.layout.title.text] = fig"
    ]
   },
   {
@@ -445,7 +455,9 @@
     "    autosize=True)\n",
     "\n",
     "fig.update_xaxes(title_text=\"GWH\", row=len(scenarios), col=1, matches='x')\n",
-    "fig.show() "
+    "fig.show()\n",
+    "\n",
+    "figure_export_list[fig.layout.title.text] = fig"
    ]
   },
   {
@@ -488,7 +500,9 @@
     "    height=50*len(scenarios),\n",
     "    autosize=True)\n",
     "fig.update_xaxes(title_text=\"ha\")\n",
-    "fig.show()"
+    "fig.show()\n",
+    "\n",
+    "figure_export_list[fig.layout.title.text] = fig"
    ]
   },
   {
@@ -520,7 +534,9 @@
     "                    autosize=True)\n",
     "fig.update_xaxes(showspikes=True)\n",
     "\n",
-    "fig.show()"
+    "fig.show()\n",
+    "\n",
+    "figure_export_list[fig.layout.title.text] = fig"
    ]
   },
   {
@@ -601,7 +617,9 @@
     "fig.update_yaxes(title=\"GW\", showspikes=True, secondary_y=False)\n",
     "fig.update_yaxes(title=\"%\", showspikes=True, secondary_y=True)\n",
     "\n",
-    "fig.show()"
+    "fig.show()\n",
+    "\n",
+    "figure_export_list[fig.layout.title.text] = fig"
    ]
   },
   {
@@ -684,7 +702,9 @@
     "    autosize=True,\n",
     "    hovermode=\"x unified\")\n",
     "fig.update_yaxes(title='GWh', showspikes=False)\n",
-    "fig.show()"
+    "fig.show()\n",
+    "\n",
+    "figure_export_list[fig.layout.title.text] = fig"
    ]
   },
   {
@@ -732,7 +752,9 @@
     "    autosize=True,\n",
     "    hovermode=\"x unified\")\n",
     "fig.update_yaxes(title='GWh', showspikes=False)\n",
-    "fig.show()"
+    "fig.show()\n",
+    "\n",
+    "figure_export_list[fig.layout.title.text] = fig"
    ]
   },
   {
@@ -782,7 +804,30 @@
     "    autosize=True)\n",
     "\n",
     "fig.update_yaxes(title_text=\"t CO2\")\n",
-    "fig.show() "
+    "fig.show()\n",
+    "\n",
+    "figure_export_list[fig.layout.title.text] = fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Export Figures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Export all figures if requested\n",
+    "if export_figures:\n",
+    "    for title, figure in figure_export_list.items():\n",
+    "        figure.write_image(os.path.join(figures_output_path,\n",
+    "                                        title.replace(' ', '_')) + '.' + figures_file_ext\n",
+    "                       )"
    ]
   }
  ],

--- a/windnode_abw/jupy/templates/scenario_analysis_comparative_template.ipynb
+++ b/windnode_abw/jupy/templates/scenario_analysis_comparative_template.ipynb
@@ -168,6 +168,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**TODO: Export pair grid plot**"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
Fix #160

Allows to export figues in comparative nb, figure title is used as filename.
The figs are stored in a dict (title: fig obj) and exported in the end (see template).

Usage:
```
create_comparative_notebook(scenarios, run_id,
                            template="scenario_analysis_comparative_template.ipynb",
                            output_path=os.path.join(wn_path[0], 'jupy'),
                            kernel_name=None,
                            force_new_results=False,
                            export_figures=False,
                            figures_output_path=None,
                            figures_file_ext='svg'):
```
Params:
`export_figures`: Set to True if you want export
`figures_output_path`: Defaults to output_path
`figures_file_ext`: png/svg/eps (defaults to 'svg')

Note: package orca is required but not available via pip. [Available options](https://github.com/plotly/orca#installation) are e.g. conda package, npm or standalone binaries.
I did the latter for testing but we maybe should switch to conda or docker windnode_abw-wide later on.

Executing results in some errors
```
11:42:04-INFO: Creating comparative notebook for 39 scenarios in /home/nesnoj/git-repos/windnode/WindNODE_ABW/windnode_abw/jupy/xxxxxx/ ...
Executing:  98%|█████████▊| 44/45 [00:53<00:00,  1.35cell/s]../../sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc:**CRASHING**:seccomp-bpf failure in syscall 0230
../../sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc:**CRASHING**:seccomp-bpf failure in syscall 0230
../../sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc:**CRASHING**:seccomp-bpf failure in syscall 0230
Executing: 100%|██████████| 45/45 [01:05<00:00,  1.46s/cell]
DONE
11:43:10-INFO: Comparative notebook successfully created!

```
but the figures are exported, example:

![Installed_Capacity_Heat_Supply](https://user-images.githubusercontent.com/15910173/90499992-93b28080-e14a-11ea-94ad-aed29aab3629.png)

**2 things remain:**
1. The layout of some plots is kind of broken, this needs to be fixed maybe using params of plotly's [`write_image()`](https://plotly.github.io/plotly.py-docs/generated/plotly.io.write_image.html). Some fine tuning is required here..
2. The export of pair grid plot is not implemented yet as it's a matplotlib figure, not plotly and therefore `write_image()` doesn't work here. I'd recommend to return the plt instances of the 3 plots to the nb and check the obj type in the export loop at the end of the template (use plt functionalities in this case)

@gplssm: If you like, you can go on. If not, I'll take care later on..